### PR TITLE
Fix macOS and Linux download URLs

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,21 +1,17 @@
 #!/usr/bin/env bash
-#
-# Copyright 2019 asdf-mlton authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 
-set -eo pipefail
+set -Eeuo pipefail
+
+trap cleanup SIGINT SIGTERM ERR
+
+cleanup() {
+  trap - SIGINT SIGTERM ERR
+  rm -rf "$ASDF_INSTALL_PATH"
+  echo
+  echo -e "\e[33mCleanup:\e[m Something went wrong!"
+  echo
+  echo "$(caller): ${BASH_COMMAND}"
+}
 
 fail() {
   echo -e "\e[31mFail:\e[m $*"
@@ -26,12 +22,6 @@ install_mlton() {
   local install_type=$1
   local version=$2
   local install_path=$3
-  local build_release
-
-  # include build version in URL for macOS
-  if [[ $(uname -s) = Darwin ]]; then
-	  build_release=-19.6
-  fi
 
   if [ "$install_type" != "version" ]; then
     fail "asdf-mlton supports release installs only"
@@ -40,8 +30,20 @@ install_mlton() {
   local platform
 
   case "$OSTYPE" in
-    darwin*) platform="darwin" ;;
-    linux*) platform="linux" ;;
+    darwin*)
+      if [[ $version -ge 20200817 ]]; then
+        platform="darwin-19.6.gmp-static"
+      else
+        platform="darwin.gmp-static"
+      fi
+      ;;
+    linux*)
+      if [[ $version -ge 20210107 ]]; then
+        platform="linux-glibc2.31"
+      else
+        platform="linux"
+      fi
+      ;;
     *) fail "Unsupported platform" ;;
   esac
 
@@ -52,23 +54,14 @@ install_mlton() {
     *) fail "Unsupported architecture" ;;
   esac
 
-  if [[ "$platform" == "darwin" ]]; then
-    platform="${platform}${build_release}.gmp-static"
-  fi
-
   local download_url="https://github.com/MLton/mlton/releases/download/on-${version}-release/mlton-${version}-1.${architecture}-${platform}.tgz"
   local source_path="${install_path}/bin/mlton.tgz"
 
-  (
-    echo "∗ Downloading and installing mlton..."
-    mkdir -p "${install_path}/bin"
-    curl --silent --location --create-dirs --output "$source_path" "$download_url" || fail "Could not download"
-    tar -zxf "$source_path" -C "$install_path" --strip-components=1 || fail "Could not uncompress"
-    echo "The installation was successful!"
-  ) || (
-    rm -rf "$install_path"
-    fail "An error occurred"
-  )
+  echo "∗ Downloading and installing mlton..."
+  mkdir -p "${install_path}/bin"
+  curl --fail --silent --location --create-dirs --output "$source_path" "$download_url"
+  tar -zxf "$source_path" -C "$install_path" --strip-components=1
+  echo "The installation was successful!"
 }
 
 install_mlton "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -26,6 +26,12 @@ install_mlton() {
   local install_type=$1
   local version=$2
   local install_path=$3
+  local build_release
+
+  # include build version in URL for macOS
+  if [[ $(uname -s) = Darwin ]]; then
+	  build_release=-19.6
+  fi
 
   if [ "$install_type" != "version" ]; then
     fail "asdf-mlton supports release installs only"
@@ -47,7 +53,7 @@ install_mlton() {
   esac
 
   if [[ "$platform" == "darwin" ]]; then
-    platform="${platform}.gmp-static"
+    platform="${platform}${build_release}.gmp-static"
   fi
 
   local download_url="https://github.com/MLton/mlton/releases/download/on-${version}-release/mlton-${version}-1.${architecture}-${platform}.tgz"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,33 +1,16 @@
 #!/usr/bin/env bash
-#
-# Copyright 2019 asdf-mlton authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 
-set -eo pipefail
+set -Eeuo pipefail
 
 sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-versions=$(
-  git ls-remote --tags https://github.com/MLton/mlton.git |
+list_all_versions() {
+  git ls-remote --tags --refs https://github.com/MLton/mlton.git |
     awk '!/({})/ {print $2}' |
-    grep -Eo "[0-9]+" |
-    sort_versions |
-    xargs
-)
+    grep -Eo "[0-9]+"
+}
 
-echo "$versions"
+list_all_versions | sort_versions | xargs echo


### PR DESCRIPTION
the `install` script, as it currently stands, attempts to download https://github.com/MLton/mlton/releases/download/on-20210117-release/mlton-20210117-1.amd64-darwin.gmp-static.tgz via:

```
curl --silent --location --create-dirs --output /Users/jrd/.asdf/installs/mlton/20210117/bin/mlton.tgz https://github.com/MLton/mlton/releases/download/on-20210117-release/mlton-20210117-1.amd64-darwin.gmp-static.tgz
```

unfortunately, assets are now tagged with the macOS version used for the build and is now https://sourceforge.net/projects/mlton/files/mlton/20210117/mlton-20210117-1.amd64-darwin-19.6.gmp-static.tgz per https://github.com/MLton/mlton/releases/:

<img width="1231" alt="image" src="https://user-images.githubusercontent.com/788303/110214873-8d23f600-7e5b-11eb-8a8e-c40ce5bca6ab.png">

i fixed this by including the macOS build version in the UR (see below). this will need occasional tweaks and the MLton build system is updated.

### After

```
[jrd@univac 06-03-21 9:17:41 ~] 4142% asdf install mlton latest
∗ Downloading and installing mlton...
The installation was successful!
[jrd@univac 06-03-21 9:18:36 ~] 4143% asdf global mlton 20210117
[jrd@univac 06-03-21 9:19:25 ~] 4144% mlton
MLton 20210117
```